### PR TITLE
Release into major version branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       component:
         description: 'Version component to increment'
         required: true
-        default: 'patch'
+        default: 'minor'
 jobs:
   build:
     name: Create Release
@@ -25,7 +25,18 @@ jobs:
       - run: echo New Version Number ${{ steps.bump.outputs.newVersion }}
 
       - name: Create Release
-        run: |
-          gh release create ${{ steps.bump.outputs.newVersion }} --title "Release ${{ steps.bump.outputs.newVersion }}" --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.bump.outputs.newVersion }}
+        run: |
+          gh release create "$NEW_VERSION" --title "Release $NEW_VERSION" --generate-notes
+
+      # Users reference the action by major version, so that branch has to
+      # point at the most recent release of its version line.
+      - name: Move the major version branch to the release
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.newVersion }}
+        run: |
+          major="${NEW_VERSION%%.*}"
+          echo "Moving branch $major to $(git rev-parse --short HEAD)"
+          git push --force origin "HEAD:refs/heads/$major"

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -5,6 +5,18 @@
 The bundled `dist/index.js` is committed, since that is what the runner executes.
 The `check-dist` workflow rebuilds it and fails when the committed bundle is out of date, so run `npm run bundle` after changing anything in `src`.
 
+## Releasing
+
+The `Release` workflow is triggered manually, creates a release with the next version number, and moves the branch of that major version to the released commit.
+Users reference the action as `fwilhe2/bump-version@v2`, so that branch has to keep pointing at the newest release of its line.
+
+Anything that can fail a workflow which worked before is a breaking change and belongs into a new major version, including a change of the Node.js version the action runs on, since self hosted runners may not have the new one.
+Cut the new line by creating its first tag and branch by hand, `v3.0` and `v3`, and leave the previous major branch where it is.
+See [fwilhe2/setup-kotlin#651](https://github.com/fwilhe2/setup-kotlin/issues/651) for how this bites users when it is not done.
+
+Release tags carry a `v` prefix and two components, `v2.0`, `v2.1`, and so on, which is why the workflow defaults to incrementing the `minor` component.
+A version of that shape has no `patch` component, and asking for one fails.
+
 ## Running the action manually
 
 Inputs are passed as `INPUT_<NAME>` environment variables, the repository to look up as `GITHUB_REPOSITORY`, and outputs are written to the file `GITHUB_OUTPUT` points at.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Get Version Number
-        uses: fwilhe2/bump-version@main
+        uses: fwilhe2/bump-version@v2
         id: bump
       - run: echo New Version Number ${{ steps.bump.outputs.newVersion }}
       - name: Create Release
@@ -38,7 +38,7 @@ Valid values are `major`, `minor`, `patch`.
 Example to update the `patch` version:
 
 ```yaml
-- uses: fwilhe2/bump-version@main
+- uses: fwilhe2/bump-version@v2
   id: bump
   with:
     component: patch
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Get Version Number
-        uses: fwilhe2/bump-version@main
+        uses: fwilhe2/bump-version@v2
         id: bump
         with:
           component: ${{ github.event.inputs.component }}
@@ -80,7 +80,7 @@ It uses `${{ github.token }}` by default, which is enough for private repositori
 Pass a different token via the `token` input if you need to.
 
 ```yaml
-- uses: fwilhe2/bump-version@main
+- uses: fwilhe2/bump-version@v2
   id: bump
   with:
     token: ${{ secrets.MY_TOKEN }}
@@ -100,6 +100,18 @@ The action fails with an error message when
 - the latest release cannot be read, for example because the repository has no release yet or the token is missing,
 - the tag of the latest release is not a version number, or
 - the version is too short to hold the requested component, for example the `patch` component of `1.0`.
+
+## Versioning
+
+Reference the action by its major version branch, `@v2`, which points at the most recent release of that line and receives compatible changes automatically.
+Pin a release tag such as `@v2.0` to stay on an exact version, or a commit sha if you want to be strict about it.
+
+Breaking changes go into a new major version, so `@v1` keeps behaving the way it did before the change.
+
+| version | notes                                                                                                                                                                |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@v2`   | validates version numbers, releases pre-releases such as `1.0.0-SNAPSHOT`, authenticates against the API, and fails instead of returning a version it could not bump |
+| `@v1`   | last release of the 1.x line, unmaintained                                                                                                                           |
 
 ## License
 


### PR DESCRIPTION
Addresses [fwilhe2/setup-kotlin#651](https://github.com/fwilhe2/setup-kotlin/issues/651) for this repository, following the same pattern as setup-kotlin: a branch per major version that points at the newest release of that line.

This repository has no such branch at all, which is why the README tells everyone `@main` — every consumer rides the default branch and picks up whatever is merged, including the behaviour changes in #798.

## Changes

- The release workflow moves the branch of the released major version, so `v2` follows every 2.x release without manual work. That is the part the issue asks for beyond the one-off fix.
- The README examples use `@v2`, plus a versioning section explaining what `@v2`, a tag and a sha each give you.
- Release tags carry a `v` prefix and two components (`v2.0`, `v2.1`) like setup-kotlin's. Such a version has no patch component, so the workflow now defaults to `minor` — asking for `patch` on `v2.0` fails by design since #798.
- The version goes through the environment instead of being interpolated into the shell script.
- `DEVEL.md` documents what counts as breaking, that the Node.js version is part of that, and how to cut a new major line.

## Why the next release is 2.0 and not 1.1

Unlike setup-kotlin, the Node.js version is not the problem here — node24 landed in `0.1.9`, so the whole 1.x line already runs on it. The break is in the merged behaviour changes:

```
bump('1.0', 'patch')  →  1.0   (before, silently unchanged)
bump('1.0', 'patch')  →  fails (now)
```

A workflow bumping the patch component of a two-segment tag succeeded before and fails now. By the standard in the issue that is breaking, so the current `main` is a new major and `v1` stays at `1.0.2`.

## Follow-up, not in this PR

Merging this alone leaves the README pointing at a `v2` that does not exist yet. After merge:

1. create branch `v1` at tag `1.0.2`, so anyone moving to `@v1` gets the last 1.x release
2. release `v2.0` from `main`, which creates the `v2` branch through the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)