### PR TITLE
Ignore major updates of typescript

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,11 @@ updates:
     ignore:
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
+      # TypeScript 6 and 7 cannot be installed at all: typescript-eslint
+      # peers on typescript <6.1.0, and ts-jest on <7, so npm ci fails with
+      # ERESOLVE before anything is built. TypeScript 7 is the native
+      # compiler, which exposes no JavaScript API for ts-jest and
+      # @rollup/plugin-typescript to use. Drop this once the toolchain
+      # follows, see https://github.com/fwilhe2/bump-version/pull/802.
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
Dependabot keeps proposing TypeScript majors that cannot be installed, most recently #802. This ignores them the same way `@types/node` majors are already ignored.

## Why they cannot be installed

`npm ci` fails before anything is built:

```
npm error peer typescript@">=4.8.4 <6.1.0" from @typescript-eslint/eslint-plugin@8.65.0
npm error Conflicting peer dependency: typescript@6.0.3
```

That range is from the current release of typescript-eslint, so TypeScript **6** is blocked as well, not just 7.

Forcing the resolution does not get further. I installed `typescript@7.0.2` with `--force` and ran the toolchain:

```
build: [!] Error: Cannot load plugin "@rollup/plugin-typescript":
           Cannot read properties of undefined (reading 'ES2015')

tests: The TypeScript compiler "typescript" (version 7.0.2) does not expose
       the JavaScript compiler API required by ts-jest.
```

TypeScript 7 is the native compiler. `ts-jest@29.4.12` declares `typescript: >=4.3 <7` deliberately, and `@rollup/plugin-typescript` reads `ts.ScriptTarget.ES2015` off an API the native package does not provide.

The hybrid setup ts-jest suggests, native compiler as `@typescript/native` plus `@typescript/typescript6` aliased as `typescript`, is not an option either: `@typescript/native` is not published, only `@typescript/native-preview`. For two source files the speed of the native compiler buys nothing anyway.

The comment in the file records when to drop the rule: once typescript-eslint peers on 6.1 or later and ts-jest lifts its cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)